### PR TITLE
Fix main server crah where subtitles where requested on the server

### DIFF
--- a/Main Server/components/hlsPlayer.js
+++ b/Main Server/components/hlsPlayer.js
@@ -86,27 +86,6 @@ export default class HlsPlayer extends Component {
         if (runningOnClient) {
             this.chromecastHandler = new cheomecastHandler(this.chromecastProgressUpdate, this.chromecastDisconnect);
         }
-
-        this.getSubtitles();
-        this.getLanguages()
-            .then(() => {
-                this.getResolutions().then(resolutions => {
-                    const directplay = resolutions[0].name === "Directplay";
-                    this.setState({
-                        resolutions: resolutions,
-                        activeResolutionLevel: resolutions.length - 1,
-                        usingDirectplay: directplay
-                    }, () => {
-                        this.getSrc(directplay).then(src => {
-                            this.chromecastHandler.setSrc(src); // TODO: Test
-                            if (this._ismounted) {
-                                this.setupHls();
-                            }
-                        })
-                    });
-
-                });
-            });
     }
 
     /**
@@ -637,6 +616,30 @@ export default class HlsPlayer extends Component {
     }
 
     componentDidMount() {
+        // TODO: Make this readable..
+        this.getSubtitles();
+        this.getLanguages()
+            .then(() => {
+                this.getResolutions().then(resolutions => {
+                    const directplay = resolutions[0].name === "Directplay";
+                    this.setState({
+                        resolutions: resolutions,
+                        activeResolutionLevel: resolutions.length - 1,
+                        usingDirectplay: directplay
+                    }, () => {
+                        this.getSrc(directplay).then(src => {
+                            this.chromecastHandler.setSrc(src); // TODO: Test
+                            this.setupHls();
+                        })
+                    });
+
+                });
+            });
+
+
+
+
+
         // Check the localStorage if the chromecast API has already been loaded, if not, load it
         let runningOnClient = typeof window !== "undefined";
         if (runningOnClient && window["gCastIncluded"] == null) {
@@ -651,10 +654,6 @@ export default class HlsPlayer extends Component {
         });
 
         this._ismounted = true;
-        // If we have found the language, we can setup HLS. If not we will wait for the language to be found
-        if (Hls.isSupported() && this.state.activeLanguageStreamIndex !== null) {
-            this.setupHls();
-        }
         this.soundBar.value = 100;
         this.seekBar.value = 0;
         this.pingInterval = setInterval(this.ping, 5000);


### PR DESCRIPTION
This is a quick fix. The code needs to be slightly refactored.

Subtitles and languages where requested from the Main Server instead of the client side (which should not be done, all contacts with the Content Server should go through the Client). This made us do an auth check on the server side which didn't succeed which made us try to redirect with next/router on the server side. This leads to a crash since you can only use next/router on the Client.

Changed so we get the available languages and subtitles on the client side instead of the server.

Fixes #81 